### PR TITLE
Replace (;) with NamedTuple() to get compatibility with Julia 1.x (te…

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,4 +9,4 @@ Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
-julia = "1.5"
+julia = "1.4"

--- a/src/requests.jl
+++ b/src/requests.jl
@@ -41,7 +41,7 @@ end
 #
 # Requests
 #
-function reqMktData(ib::Connection, tickerId::Int, contract::Contract, genericTicks::String, snapshot::Bool, regulatorySnaphsot::Bool=false, mktDataOptions::NamedTuple=(;))
+function reqMktData(ib::Connection, tickerId::Int, contract::Contract, genericTicks::String, snapshot::Bool, regulatorySnaphsot::Bool=false, mktDataOptions::NamedTuple=NamedTuple())
 
   o = enc()
 
@@ -266,7 +266,7 @@ function reqContractDetails(ib::Connection, reqId::Int, contract::Contract)
   sendmsg(ib, o)
 end
 
-function reqMktDepth(ib::Connection, tickerId::Int, contract::Contract, numRows::Int, isSmartDepth::Bool, mktDepthOptions::NamedTuple=(;))
+function reqMktDepth(ib::Connection, tickerId::Int, contract::Contract, numRows::Int, isSmartDepth::Bool, mktDepthOptions::NamedTuple=NamedTuple())
 
   o = enc()
 
@@ -330,7 +330,7 @@ function replaceFA(ib::Connection, reqId::Int, faDataType::FaDataType, xml::Stri
   sendmsg(ib, o)
 end
 
-function reqHistoricalData(ib::Connection, tickerId::Int, contract::Contract, endDateTime::String, durationStr::String, barSizeSetting::String, whatToShow::String, useRTH::Bool, formatDate::Int, keepUpToDate::Bool, chartOptions::NamedTuple=(;))
+function reqHistoricalData(ib::Connection, tickerId::Int, contract::Contract, endDateTime::String, durationStr::String, barSizeSetting::String, whatToShow::String, useRTH::Bool, formatDate::Int, keepUpToDate::Bool, chartOptions::NamedTuple=NamedTuple())
 
   o = enc()
 
@@ -374,7 +374,7 @@ function exerciseOptions(ib::Connection, tickerId::Int, contract::Contract, exer
   sendmsg(ib, o)
 end
 
-function reqScannerSubscription(ib::Connection, tickerId::Int, subscription::ScannerSubscription, scannerSubscriptionOptions::NamedTuple=(;), scannerSubscriptionFilterOptions::NamedTuple=(;))
+function reqScannerSubscription(ib::Connection, tickerId::Int, subscription::ScannerSubscription, scannerSubscriptionOptions::NamedTuple=NamedTuple(), scannerSubscriptionFilterOptions::NamedTuple=NamedTuple())
 
   o = enc()
 
@@ -400,7 +400,7 @@ cancelHistoricalData(ib::Connection, tickerId::Int) =  req_simple(ib, 25, 1, tic
 
 reqCurrentTime(ib::Connection) = req_simple(ib, 49, 1) ### REQ_CURRENT_TIME
 
-function reqRealTimeBars(ib::Connection, tickerId::Int, contract::Contract, barSize::Int, whatToShow::String, useRTH::Bool, realTimeBarsOptions::NamedTuple=(;))
+function reqRealTimeBars(ib::Connection, tickerId::Int, contract::Contract, barSize::Int, whatToShow::String, useRTH::Bool, realTimeBarsOptions::NamedTuple=NamedTuple())
 
   o = enc()
 
@@ -417,7 +417,7 @@ end
 
 cancelRealTimeBars(ib::Connection, tickerId::Int) = req_simple(ib, 51, 1, tickerId) ### CANCEL_REAL_TIME_BARS
 
-function reqFundamentalData(ib::Connection, reqId::Int, contract::Contract, reportType::String, fundamentalDataOptions::NamedTuple=(;))
+function reqFundamentalData(ib::Connection, reqId::Int, contract::Contract, reportType::String, fundamentalDataOptions::NamedTuple=NamedTuple())
 
   o = enc()
 
@@ -432,7 +432,7 @@ end
 
 cancelFundamentalData(ib::Connection, reqId::Int) = req_simple(ib, 53, 1, reqId) ### CANCEL_FUNDAMENTAL_DATA
 
-function calculateImpliedVolatility(ib::Connection, reqId::Int, contract::Contract, optionPrice::Float64, underPrice::Float64, miscOptions::NamedTuple=(;))
+function calculateImpliedVolatility(ib::Connection, reqId::Int, contract::Contract, optionPrice::Float64, underPrice::Float64, miscOptions::NamedTuple=NamedTuple())
 
   o = enc()
 
@@ -446,7 +446,7 @@ function calculateImpliedVolatility(ib::Connection, reqId::Int, contract::Contra
   sendmsg(ib, o)
 end
 
-function calculateOptionPrice(ib::Connection, reqId::Int, contract::Contract, volatility::Float64, underPrice::Float64, miscOptions::NamedTuple=(;))
+function calculateOptionPrice(ib::Connection, reqId::Int, contract::Contract, volatility::Float64, underPrice::Float64, miscOptions::NamedTuple=NamedTuple())
 
   o = enc()
 
@@ -514,7 +514,7 @@ reqMktDepthExchanges(ib::Connection) = req_simple(ib, 82) ### REQ_MKT_DEPTH_EXCH
 
 reqSmartComponents(ib::Connection, reqId::Int, bboExchange::String) = req_simple(ib, 83, reqId, bboExchange) ### REQ_SMART_COMPONENTS
 
-function reqNewsArticle(ib::Connection, requestId::Int, providerCode::String, articleId::String, newsArticleOptions::NamedTuple=(;))
+function reqNewsArticle(ib::Connection, requestId::Int, providerCode::String, articleId::String, newsArticleOptions::NamedTuple=NamedTuple())
 
   o = enc()
 
@@ -529,7 +529,7 @@ end
 
 reqNewsProviders(ib::Connection) = req_simple(ib, 85) ### REQ_NEWS_PROVIDERS
 
-function reqHistoricalNews(ib::Connection, requestId::Int, conId::Int, providerCodes::String, startDateTime::String, endDateTime::String, totalResults::Int, historicalNewsOptions::NamedTuple=(;))
+function reqHistoricalNews(ib::Connection, requestId::Int, conId::Int, providerCodes::String, startDateTime::String, endDateTime::String, totalResults::Int, historicalNewsOptions::NamedTuple=NamedTuple())
 
   o = enc()
 
@@ -586,7 +586,7 @@ reqPnLSingle(ib::Connection, reqId::Int, account::String, modelCode::String, con
 
 cancelPnLSingle(ib::Connection, reqId::Int) = req_simple(ib, 95, reqId) ### CANCEL_PNL_SINGLE
 
-function reqHistoricalTicks(ib::Connection, reqId::Int, contract::Contract, startDateTime::String, endDateTime::String, numberOfTicks::Int, whatToShow::String, useRTH::Bool, ignoreSize::Bool, miscOptions::NamedTuple=(;))
+function reqHistoricalTicks(ib::Connection, reqId::Int, contract::Contract, startDateTime::String, endDateTime::String, numberOfTicks::Int, whatToShow::String, useRTH::Bool, ignoreSize::Bool, miscOptions::NamedTuple=NamedTuple())
 
   o = enc()
 

--- a/src/types_mutable.jl
+++ b/src/types_mutable.jl
@@ -160,14 +160,14 @@ mutable struct Order
   parentPermId::Union{Int,Nothing}
   usePriceMgmtAlgo::Union{Bool,Nothing}
 end
-Order() = Order(0, 0, 0, ns, 0.0, ns, nothing, nothing, ns, ns, ns, ns, 0, ns, true, 0,
-                false, false, 0, 0, false, false, ns, ns, ns, false, nothing, nothing,
-                false, nothing, nothing, ns, ns, ns, ns, ns, CUSTOMER, 0, ns, -1, 0.0,
-                true, true, nothing, false, UNSET, fill(nothing, 5)..., false, false,
-                nothing, nothing, ns, nothing, 0, ns, ns, ns, ns, false, 0, ns, false,
-                fill(nothing, 9)..., false, nothing, nothing, false, fill(ns, 8)...,
-                (;), (;), ns, false, false, false, ns, [],
-                (;), 0, 0.0, false, 0, ns, ns, fill(nothing, 4)..., 0, nothing, [],
+Order() = Order(0, 0, 0, ns, 0.0, ns, nothing, nothing, ns, ns, ns, ns, 0, ns, true, 0, #16
+                false, false, 0, 0, false, false, ns, ns, ns, false, nothing, nothing, #28
+                false, nothing, nothing, ns, ns, ns, ns, ns, CUSTOMER, 0, ns, -1, 0.0, #41
+                true, true, nothing, false, UNSET, fill(nothing, 5)..., false, false, #53
+                nothing, nothing, ns, nothing, 0, ns, ns, ns, ns, false, 0, ns, false, #66
+                fill(nothing, 9)..., false, nothing, nothing, false, fill(ns, 8)..., #87
+				NamedTuple(), NamedTuple(), ns, false, false, false, ns, [],
+				NamedTuple(), 0, 0.0, false, 0, ns, ns, fill(nothing, 4)..., 0, nothing, [],
                 false, false, ns, SoftDollarTier(), nothing, ns, ns, ns, ns, false, false, false,
                 ns, nothing, nothing, false, ns, false, false, nothing, nothing)
 

--- a/src/types_private.jl
+++ b/src/types_private.jl
@@ -58,7 +58,7 @@ mutable struct ContractDetails
   notes::String
 end
 ContractDetails() = ContractDetails(Contract(), ns, 0.0, ns, ns, 0, 0, fill(ns, 9)..., 0,
-                                    nothing, nothing, fill(ns, 6)..., (;),
+                                    nothing, nothing, fill(ns, 6)..., NamedTuple(),
                                     fill(ns, 5)..., false, false, 0, false, ns, ns, ns, ns,
                                     false, ns)
 


### PR DESCRIPTION
With the existing master on lbilli/Jib.jl I get stack traces when executing Jib.Order()

These changes remove that stack trace and appear to give correct behaviour on Julia 1.4.2
It also passes all the tests on Julia 1.4.2 when I run "test Jib" from the REPL package manager