### PR TITLE
Make default wrapper methods print their name.

### DIFF
--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -87,9 +87,11 @@ struct Wrapper
 end
 function Wrapper(; kw...)
 
-  default = (_...) -> println("default implementation")
+  function default(field::Symbol)
+    return (_...) -> println("$field default implementation")
+  end
 
-  args = (get(kw, a, default) for a ∈ fieldnames(Wrapper))
+  args = (get(kw, a, default(a)) for a ∈ fieldnames(Wrapper))
 
   Wrapper(args...)
 end


### PR DESCRIPTION
The default method stub doesn't print its name, which makes it hard to know which messages are being handled by the default stub because they all print `default implementation`. This adds the field name to the message, for example, `managedAccounts default implementation`.