### PR TITLE
Update wrapper.jl - overload Base.merge for Wrapper type

### DIFF
--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -117,7 +117,7 @@ Base.getproperty(w::Wrapper, name::Symbol) = get(getfield(w, :cb), name) do
 
 
 Base.propertynames(w::Wrapper) = getfield(w, :cb) |> keys |> collect
-
+Base.merge(nt::NamedTuple, w::Wrapper) = let pns=propertynames(w);  merge(nt, NamedTuple{(pns...,)}(getproperty.(Ref(w), pns)))  end
 
 function Base.setproperty!(w::Wrapper, name::Symbol, f)
 


### PR DESCRIPTION
Allows a Wrapper to be splatted, so that only a small handful of new functions need be defined, enabling patterns like this:
```
d, sw = simple_wrap()
function tickByTickAllLast(a, b, c, d, e, f, g, h) 
    #= =# 
end
w = Wrapper(; sw..., tickByTickAllLast) 
# `w` is exactly like `sw` but with a custom `tickByTickAllLast` callback
```