### PR TITLE
Use DataFrame upon request

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,48 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+    tags: ['*']
+  pull_request:
+  workflow_dispatch:
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
+      actions: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        version:            
+          - '1.10'
+          - '1.9'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v4.1.0
+        with:
+          target: 10%
+          file: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: oliviermilla/Jib.jl

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,16 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,33 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      lookback:
+        default: 3
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Edit the following line to reflect the actual name of the GitHub Secret containing your private key
+          ssh: ${{ secrets.DOCUMENTER_KEY }}
+          # ssh: ${{ secrets.NAME_OF_MY_SSH_PRIVATE_KEY_SECRET }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,12 @@ version = "0.20.4"
 
 [deps]
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[weakdeps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+
+[extensions]
+DataFramesExt = "DataFrames"
 
 [compat]
 DataFrames = "1.0"
@@ -15,4 +20,4 @@ julia = "1.7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "DataFrames"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Jib"
 uuid = "f310f2d2-a263-11e8-3998-47bd686f18f7"
-authors = ["Luca Billi <noreply.section+dev@gmail.com>"]
+authors = ["Luca Billi <noreply.section+dev@gmail.com>", "Olivier Milla <olivier.milla@hey.com>"]
 version = "0.20.4"
 
 [deps]
@@ -14,11 +14,10 @@ DataFramesExt = "DataFrames"
 
 [compat]
 DataFrames = "1.0"
-julia = "1.7"
+julia = "1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0" # Required by julia < 1.9 package manager.
 
 [targets]
 test = ["Test", "DataFrames"]

--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ julia = "1.7"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0" # Required by julia < 1.9 package manager.
 
 [targets]
 test = ["Test", "DataFrames"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,15 @@ authors = ["Luca Billi <noreply.section+dev@gmail.com>"]
 version = "0.20.4"
 
 [deps]
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 
 [compat]
+DataFrames = "1.0"
 julia = "1.7"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/README.md
+++ b/README.md
@@ -78,12 +78,16 @@ Jib.disconnect(ib)
 ##### Foreground vs. Background Processing
 It is possible to process the server responses either within the main process
 or in a separate background `Task`:
-- **foreground processing** is triggered by invoking `Jib.check_all(ib, wrap)`.
+- **foreground processing** is triggered by invoking `Jib.check_all(ib, wrap, Tab=Dict)`.
   It is the user's responsibility to call it on a **regular basis**,
   especially when data are streaming in.
-- **background processing** is started by `Jib.start_reader(ib, wrap)`.
+- **background processing** is started by `Jib.start_reader(ib, wrap, Tab=Dict)`.
   A separate `Task` is started in the background, which monitors the connection and processes
   the responses as they arrive.
+
+Tab is the sink format. that is used when applicable. The library supports an extension for 
+DataFrames (just pass `DataFrame` as a last parameter to the above functions), otherwise 
+you'll receive a Dict as a default format.
 
 To avoid undesired effects, the two approaches should not be mixed together
 on the same connection.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Jib
 
+[![Build Status](https://github.com/oliviermilla/Jib.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/oliviermilla/Jib.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![codecov](https://codecov.io/gh/oliviermilla/Jib.jl/graph/badge.svg?token=7SAX9EXGHM)](https://codecov.io/gh/oliviermilla/Jib.jl)
+
 **A Julia implementation of Interactive Brokers API**
 
 `Jib` is a native [Julia](https://julialang.org/) client that implements

--- a/data/wrapper_signatures.jl
+++ b/data/wrapper_signatures.jl
@@ -48,7 +48,7 @@ managedAccounts(accountsList::String)
 
 receiveFA(faDataType::FaDataType, xml::String)
 
-historicalData(reqId::Int, bar::DataFrame)
+historicalData(reqId::Int, bar::Dict)
 
 scannerParameters(xml::String)
 
@@ -106,15 +106,15 @@ familyCodes(familyCodes::Vector{FamilyCode})
 
 symbolSamples(reqId::Int, contractDescriptions::Vector{ContractDescription})
 
-mktDepthExchanges(depthMktDataDescriptions::DataFrame)
+mktDepthExchanges(depthMktDataDescriptions::Dict)
 
 tickNews(tickerId::Int, timeStamp::Int, providerCode::String, articleId::String, headline::String, extraData::String)
 
-smartComponents(reqId::Int, theMap::DataFrame)
+smartComponents(reqId::Int, theMap::Dict)
 
 tickReqParams(tickerId::Int, minTick::Union{Float64,Nothing}, bboExchange::String, snapshotPermissions::Int)
 
-newsProviders(newsProviders::DataFrame)
+newsProviders(newsProviders::Dict)
 
 newsArticle(requestId::Int, articleType::Int, articleText::String)
 
@@ -124,7 +124,7 @@ historicalNewsEnd(requestId::Int, hasMore::Bool)
 
 headTimestamp(reqId::Int, headTimestamp::String)
 
-histogramData(reqId::Int, data::DataFrame)
+histogramData(reqId::Int, data::Dict)
 
 historicalDataUpdate(reqId::Int, bar::Bar)
 
@@ -132,17 +132,17 @@ rerouteMktDataReq(reqId::Int, conid::Int, exchange::String)
 
 rerouteMktDepthReq(reqId::Int, conid::Int, exchange::String)
 
-marketRule(marketRuleId::Int, priceIncrements::DataFrame)
+marketRule(marketRuleId::Int, priceIncrements::Dict)
 
 pnl(reqId::Int, dailyPnL::Float64, unrealizedPnL::Float64, realizedPnL::Float64)
 
 pnlSingle(reqId::Int, pos::Int, dailyPnL::Float64, unrealizedPnL::Union{Float64,Nothing}, realizedPnL::Union{Float64,Nothing}, value::Float64)
 
-historicalTicks(reqId::Int, ticks::DataFrame, done::Bool)
+historicalTicks(reqId::Int, ticks::Dict, done::Bool)
 
-historicalTicksBidAsk(reqId::Int, ticks::DataFrame, done::Bool)
+historicalTicksBidAsk(reqId::Int, ticks::Dict, done::Bool)
 
-historicalTicksLast(reqId::Int, ticks::DataFrame, done::Bool)
+historicalTicksLast(reqId::Int, ticks::Dict, done::Bool)
 
 tickByTickAllLast(reqId::Int, tickType::Int, time::Int, price::Float64, size::Float64, attribs::TickAttribLast, exchange::String, specialConditions::String)
 
@@ -162,6 +162,6 @@ wshMetaData(reqId::Int, dataJson::String)
 
 wshEventData(reqId::Int, dataJson::String)
 
-historicalSchedule(reqId::Int, startDateTime::String, endDateTime::String, timeZone::String, sessions::DataFrame)
+historicalSchedule(reqId::Int, startDateTime::String, endDateTime::String, timeZone::String, sessions::Dict)
 
 userInfo(reqId::Int, whiteBrandingId::String)

--- a/ext/DataFramesExt.jl
+++ b/ext/DataFramesExt.jl
@@ -1,0 +1,21 @@
+module DataFramesExt
+
+import Jib
+
+using DataFrames
+
+function Jib.Reader.fill_table(cols, n::Int, it, Tab::Type{<:DataFrame})
+
+    df = Tab([k => Vector{T}(undef, n) for (k, T) ∈ pairs(cols)];
+                   copycols=false)
+  
+    nr, nc = size(df)
+  
+    for r ∈ 1:nr, c ∈ 1:nc
+      df[r, c] = Jib.Reader.pop(it)
+    end
+  
+    df
+  end
+
+end

--- a/src/Jib.jl
+++ b/src/Jib.jl
@@ -1,7 +1,6 @@
 module Jib
 
-using DataFrames,
-      Sockets
+using Sockets
 
 include("client.jl")
 include("enums.jl")

--- a/src/decode.jl
+++ b/src/decode.jl
@@ -6,7 +6,7 @@ include("ticktype.jl")
 # Make a shortcut
 const pop = popfirst!
 
-function decode(it, w, ver)
+function decode(it, w, ver, Tab=Dict)
 
   # The first field is the message ID
   id::Int = pop(it)
@@ -23,7 +23,7 @@ function decode(it, w, ver)
 
   else
     try
-      f(it, w, ver)
+      f(it, w, ver, Tab)
     catch e
       @error "decode(): exception caught" M=it.msg
       # Print stacktrace to stderr

--- a/src/process.jl
+++ b/src/process.jl
@@ -1,5 +1,3 @@
-using DataFrames
-
 import ...Bar,
        ...ComboLeg,
        ...CommissionReport,
@@ -59,18 +57,20 @@ function unmask(T::Type{NamedTuple{M,NTuple{N,Bool}}}, mask) where {M,N}
 end
 
 
-function fill_df(cols, n, it)
+function fill_table(cols, n::Int, it, Tab::Type{<:Dict}=Dict)
 
-  df = DataFrame([k => Vector{T}(undef, n) for (k, T) ∈ pairs(cols)];
-                 copycols=false)
+  dict = Tab{Symbol, Vector}()
 
-  nr, nc = size(df)
-
-  for r ∈ 1:nr, c ∈ 1:nc
-    df[r, c] = pop(it)
+  for (k, T) ∈ pairs(cols)
+    symb = Symbol(k)
+    dict[symb] = Vector{T}(undef, n)
+  end
+  
+  for r ∈ 1:n, c ∈ keys(dict)
+    dict[c][r] = pop(it)
   end
 
-  df
+  dict
 end
 
 
@@ -82,7 +82,7 @@ Collection of parsers indexed by message ID
 const process = Dict(
 
   # TICK_PRICE
-   1 => function(it, w, ver)
+   1 => function(it, w, ver, Tab=Dict)
 
           tickerId::Int,
           ticktype::Int,
@@ -94,7 +94,7 @@ const process = Dict(
         end,
 
   # TICK_SIZE
-   2 => function(it, w, ver)
+   2 => function(it, w, ver, Tab=Dict)
 
           tickerId::Int,
           ticktype::Int,
@@ -104,13 +104,13 @@ const process = Dict(
         end,
 
   # ORDER_STATUS
-   3 => (it, w, ver) -> w.orderStatus(slurp((Int,String,Float64,Float64,Float64,Int,Int,Float64,Int,String,Float64), it)...),
+   3 => (it, w, ver, Tab=Dict) -> w.orderStatus(slurp((Int,String,Float64,Float64,Float64,Int,Int,Float64,Int,String,Float64), it)...),
 
   # ERR_MSG
-   4 => (it, w, ver) -> w.error(slurp((Int,Int,String,String), it)...),
+   4 => (it, w, ver, Tab=Dict) -> w.error(slurp((Int,Int,String,String), it)...),
 
   # OPEN_ORDER
-   5 => function(it, w, ver)
+   5 => function(it, w, ver, Tab=Dict)
 
           o = Order()
           c = Contract()
@@ -276,10 +276,10 @@ const process = Dict(
         end,
 
   # ACCT_VALUE
-   6 => (it, w, ver) -> w.updateAccountValue(collect(String, take(it, 4))...),
+   6 => (it, w, ver, Tab=Dict) -> w.updateAccountValue(collect(String, take(it, 4))...),
 
   # PORTFOLIO_VALUE
-   7 => function(it, w, ver)
+   7 => function(it, w, ver, Tab=Dict)
 
           c = Contract()
 
@@ -289,13 +289,13 @@ const process = Dict(
         end,
 
   # ACCT_UPDATE_TIME
-   8 => (it, w, ver) -> w.updateAccountTime(slurp(String, it)),
+   8 => (it, w, ver, Tab=Dict) -> w.updateAccountTime(slurp(String, it)),
 
   # NEXT_VALID_ID
-   9 => (it, w, ver) -> w.nextValidId(slurp(Int, it)),
+   9 => (it, w, ver, Tab=Dict) -> w.nextValidId(slurp(Int, it)),
 
   # CONTRACT_DATA
-  10 => function(it, w, ver)
+  10 => function(it, w, ver, Tab=Dict)
 
           reqId::Int = pop(it)
 
@@ -342,7 +342,7 @@ const process = Dict(
         end,
 
   # EXECUTION_DATA
-  11 => function(it, w, ver)
+  11 => function(it, w, ver, Tab=Dict)
 
           reqId::Int,
           orderId = it
@@ -360,22 +360,22 @@ const process = Dict(
         end,
 
   # MARKET_DEPTH
-  12 => (it, w, ver) -> w.updateMktDepth(slurp((Int,Int,Int,Int,Float64,Float64), it)...),
+  12 => (it, w, ver, Tab=Dict) -> w.updateMktDepth(slurp((Int,Int,Int,Int,Float64,Float64), it)...),
 
   # MARKET_DEPTH_L2
-  13 => (it, w, ver) -> w.updateMktDepthL2(slurp((Int,Int,String,Int,Int,Float64,Float64,Bool), it)...),
+  13 => (it, w, ver, Tab=Dict) -> w.updateMktDepthL2(slurp((Int,Int,String,Int,Int,Float64,Float64,Bool), it)...),
 
   # NEWS_BULLETINS
-  14 => (it, w, ver) -> w.updateNewsBulletin(slurp((Int,Int,String,String), it)...),
+  14 => (it, w, ver, Tab=Dict) -> w.updateNewsBulletin(slurp((Int,Int,String,String), it)...),
 
   # MANAGED_ACCTS
-  15 => (it, w, ver) -> w.managedAccounts(slurp(String, it)),
+  15 => (it, w, ver, Tab=Dict) -> w.managedAccounts(slurp(String, it)),
 
   # RECEIVE_FA
-  16 => (it, w, ver) -> w.receiveFA(slurp((FaDataType,String), it)...),
+  16 => (it, w, ver, Tab=Dict) -> w.receiveFA(slurp((FaDataType,String), it)...),
 
   # HISTORICAL_DATA
-  17 => function(it, w, ver)
+  17 => function(it, w, ver, Tab=Dict)
 
           reqId::Int = pop(it)
 
@@ -384,15 +384,15 @@ const process = Dict(
 
           n::Int = pop(it)
 
-          df = fill_df((time=String, open=Float64, high=Float64, low=Float64,
+          df = fill_table((time=String, open=Float64, high=Float64, low=Float64,
                         close=Float64, volume=Float64, wap=Float64, count=Int),
-                       n, it)
+                       n, it, Tab)
 
           w.historicalData(reqId, df)
         end,
 
   # BOND_CONTRACT_DATA
-  18 => function(it, w, ver)
+  18 => function(it, w, ver, Tab=Dict)
 
           reqId::Int = pop(it)
 
@@ -442,10 +442,10 @@ const process = Dict(
         end,
 
   # SCANNER_PARAMETERS
-  19 => (it, w, ver) -> w.scannerParameters(slurp(String, it)),
+  19 => (it, w, ver, Tab=Dict) -> w.scannerParameters(slurp(String, it)),
 
   # SCANNER_DATA
-  20 => function(it, w, ver)
+  20 => function(it, w, ver, Tab=Dict)
 
           tickerId::Int,
           n::Int = it
@@ -475,7 +475,7 @@ const process = Dict(
         end,
 
   # TICK_OPTION_COMPUTATION
-  21 => function(it, w, ver)
+  21 => function(it, w, ver, Tab=Dict)
 
           tickerId::Int,
           ticktype::Int,
@@ -493,7 +493,7 @@ const process = Dict(
         end,
 
   # TICK_GENERIC
-  45 => function(it, w, ver)
+  45 => function(it, w, ver, Tab=Dict)
 
           tickerId::Int,
           ticktype::Int,
@@ -503,7 +503,7 @@ const process = Dict(
         end,
 
   # TICK_STRING
-  46 => function(it, w, ver)
+  46 => function(it, w, ver, Tab=Dict)
 
           tickerId::Int,
           ticktype::Int,
@@ -513,7 +513,7 @@ const process = Dict(
         end,
 
   # TICK_EFP
-  47 => function(it, w, ver)
+  47 => function(it, w, ver, Tab=Dict)
 
           tickerId::Int,
           ticktype::Int = it
@@ -522,28 +522,28 @@ const process = Dict(
         end,
 
   # CURRENT_TIME
-  49 => (it, w, ver) -> w.currentTime(slurp(Int, it)),
+  49 => (it, w, ver, Tab=Dict) -> w.currentTime(slurp(Int, it)),
 
   # REAL_TIME_BARS
-  50 => (it, w, ver) -> w.realtimeBar(slurp((Int,Int,Float64,Float64,Float64,Float64,Float64,Float64,Int), it)...),
+  50 => (it, w, ver, Tab=Dict) -> w.realtimeBar(slurp((Int,Int,Float64,Float64,Float64,Float64,Float64,Float64,Int), it)...),
 
   # FUNDAMENTAL_DATA
-  51 => (it, w, ver) -> w.fundamentalData(slurp((Int,String), it)...),
+  51 => (it, w, ver, Tab=Dict) -> w.fundamentalData(slurp((Int,String), it)...),
 
   # CONTRACT_DATA_END
-  52 => (it, w, ver) -> w.contractDetailsEnd(slurp(Int, it)),
+  52 => (it, w, ver, Tab=Dict) -> w.contractDetailsEnd(slurp(Int, it)),
 
   # OPEN_ORDER_END
-  53 => (it, w, ver) -> w.openOrderEnd(),
+  53 => (it, w, ver, Tab=Dict) -> w.openOrderEnd(),
 
   # ACCT_DOWNLOAD_END
-  54 => (it, w, ver) -> w.accountDownloadEnd(slurp(String, it)),
+  54 => (it, w, ver, Tab=Dict) -> w.accountDownloadEnd(slurp(String, it)),
 
   # EXECUTION_DATA_END
-  55 => (it, w, ver) -> w.execDetailsEnd(slurp(Int, it)),
+  55 => (it, w, ver, Tab=Dict) -> w.execDetailsEnd(slurp(Int, it)),
 
   # DELTA_NEUTRAL_VALIDATION
-  56 => function(it, w, ver)
+  56 => function(it, w, ver, Tab=Dict)
 
           reqId::Int = pop(it)
 
@@ -551,16 +551,16 @@ const process = Dict(
         end,
 
   # TICK_SNAPSHOT_END
-  57 => (it, w, ver) -> w.tickSnapshotEnd(slurp(Int, it)),
+  57 => (it, w, ver, Tab=Dict) -> w.tickSnapshotEnd(slurp(Int, it)),
 
   # MARKET_DATA_TYPE
-  58 => (it, w, ver) -> w.marketDataType(slurp((Int,MarketDataType), it)...),
+  58 => (it, w, ver, Tab=Dict) -> w.marketDataType(slurp((Int,MarketDataType), it)...),
 
   # COMMISSION_REPORT
-  59 => (it, w, ver) -> w.commissionReport(slurp(CommissionReport, it)),
+  59 => (it, w, ver, Tab=Dict) -> w.commissionReport(slurp(CommissionReport, it)),
 
   # POSITION_DATA
-  61 => function(it, w, ver)
+  61 => function(it, w, ver, Tab=Dict)
 
           account::String = pop(it)
 
@@ -571,10 +571,10 @@ const process = Dict(
         end,
 
   # POSITION_END
-  62 => (it, w, ver) -> w.positionEnd(),
+  62 => (it, w, ver, Tab=Dict) -> w.positionEnd(),
 
   # ACCOUNT_SUMMARY
-  63 => function(it, w, ver)
+  63 => function(it, w, ver, Tab=Dict)
 
           reqId::Int = pop(it)
 
@@ -582,28 +582,28 @@ const process = Dict(
         end,
 
   # ACCOUNT_SUMMARY_END
-  64 => (it, w, ver) -> w.accountSummaryEnd(slurp(Int, it)),
+  64 => (it, w, ver, Tab=Dict) -> w.accountSummaryEnd(slurp(Int, it)),
 
   # VERIFY_MESSAGE_API
-  65 => (it, w, ver) -> w.verifyMessageAPI(slurp(String, it)),
+  65 => (it, w, ver, Tab=Dict) -> w.verifyMessageAPI(slurp(String, it)),
 
   # VERIFY_COMPLETED
-  66 => (it, w, ver) -> w.verifyCompleted(slurp((Bool,String), it)...),
+  66 => (it, w, ver, Tab=Dict) -> w.verifyCompleted(slurp((Bool,String), it)...),
 
   # DISPLAY_GROUP_LIST
-  67 => (it, w, ver) -> w.displayGroupList(slurp((Int,String), it)...),
+  67 => (it, w, ver, Tab=Dict) -> w.displayGroupList(slurp((Int,String), it)...),
 
   # DISPLAY_GROUP_UPDATED
-  68 => (it, w, ver) -> w.displayGroupUpdated(slurp((Int,String), it)...),
+  68 => (it, w, ver, Tab=Dict) -> w.displayGroupUpdated(slurp((Int,String), it)...),
 
   # VERIFY_AND_AUTH_MESSAGE_API
-  69 => (it, w, ver) -> w.verifyAndAuthMessageAPI(collect(String, take(it, 2))...),
+  69 => (it, w, ver, Tab=Dict) -> w.verifyAndAuthMessageAPI(collect(String, take(it, 2))...),
 
   # VERIFY_AND_AUTH_COMPLETED
-  70 => (it, w, ver) -> w.verifyAndAuthCompleted(slurp((Bool,String), it)...),
+  70 => (it, w, ver, Tab=Dict) -> w.verifyAndAuthCompleted(slurp((Bool,String), it)...),
 
   # POSITION_MULTI
-  71 => function(it, w, ver)
+  71 => function(it, w, ver, Tab=Dict)
 
           reqId::Int,
           account::String = it
@@ -619,16 +619,16 @@ const process = Dict(
         end,
 
   # POSITION_MULTI_END
-  72 => (it, w, ver) -> w.positionMultiEnd(slurp(Int, it)),
+  72 => (it, w, ver, Tab=Dict) -> w.positionMultiEnd(slurp(Int, it)),
 
   # ACCOUNT_UPDATE_MULTI
-  73 => (it, w, ver) -> w.accountUpdateMulti(slurp(Int, it), collect(String, take(it, 5))...),
+  73 => (it, w, ver, Tab=Dict) -> w.accountUpdateMulti(slurp(Int, it), collect(String, take(it, 5))...),
 
   # ACCOUNT_UPDATE_MULTI_END
-  74 => (it, w, ver) -> w.accountUpdateMultiEnd(slurp(Int, it)),
+  74 => (it, w, ver, Tab=Dict) -> w.accountUpdateMultiEnd(slurp(Int, it)),
 
   # SECURITY_DEFINITION_OPTION_PARAMETER
-  75 => function(it, w, ver)
+  75 => function(it, w, ver, Tab=Dict)
 
           args = slurp((Int,String,Int,String,String), it)
 
@@ -642,10 +642,10 @@ const process = Dict(
         end,
 
   # SECURITY_DEFINITION_OPTION_PARAMETER_END
-  76 => (it, w, ver) -> w.securityDefinitionOptionalParameterEnd(slurp(Int, it)),
+  76 => (it, w, ver, Tab=Dict) -> w.securityDefinitionOptionalParameterEnd(slurp(Int, it)),
 
   # SOFT_DOLLAR_TIERS
-  77 => function(it, w, ver)
+  77 => function(it, w, ver, Tab=Dict)
 
           reqId::Int,
           n::Int = it
@@ -654,7 +654,7 @@ const process = Dict(
         end,
 
   # FAMILY_CODES
-  78 => function(it, w, ver)
+  78 => function(it, w, ver, Tab=Dict)
 
           n::Int = pop(it)
 
@@ -662,7 +662,7 @@ const process = Dict(
         end,
 
   # SYMBOL_SAMPLES
-  79 => function(it, w, ver)
+  79 => function(it, w, ver, Tab=Dict)
 
           reqId::Int,
           n::Int = it
@@ -691,36 +691,36 @@ const process = Dict(
         end,
 
   # MKT_DEPTH_EXCHANGES
-  80 => function(it, w, ver)
+  80 => function(it, w, ver, Tab=Dict)
 
           n::Int = pop(it)
 
-          df = fill_df((exchange=String, secType=String, listingExch=String,
+          df = fill_table((exchange=String, secType=String, listingExch=String,
                         serviceDataType=String, aggGroup=Union{Int,Nothing}),
-                       n, it)
+                       n, it, Tab)
 
           w.mktDepthExchanges(df)
         end,
 
   # TICK_REQ_PARAMS
-  81 => (it, w, ver) -> w.tickReqParams(slurp((Int,Float64,String,Int), it)...),
+  81 => (it, w, ver, Tab=Dict) -> w.tickReqParams(slurp((Int,Float64,String,Int), it)...),
 
   # SMART_COMPONENTS
-  82 => function(it, w, ver)
+  82 => function(it, w, ver, Tab=Dict)
 
           reqId::Int,
           n::Int = it
 
-          df = fill_df((bit=Int, exchange=String, exchangeLetter=String), n, it)
+          df = fill_table((bit=Int, exchange=String, exchangeLetter=String), n, it, Tab)
 
           w.smartComponents(reqId, df)
         end,
 
   # NEWS_ARTICLE
-  83 => (it, w, ver) -> w.newsArticle(slurp((Int,Int,String), it)...),
+  83 => (it, w, ver, Tab=Dict) -> w.newsArticle(slurp((Int,Int,String), it)...),
 
   # TICK_NEWS
-  84 => function (it, w, ver)
+  84 => function (it, w, ver, Tab=Dict)
 
           args = slurp((Int,Int,String,String,String,String), it)
 
@@ -728,37 +728,37 @@ const process = Dict(
         end,
 
   # NEWS_PROVIDERS
-  85 => function(it, w, ver)
+  85 => function(it, w, ver, Tab=Dict)
 
           n::Int = pop(it)
 
-          df = fill_df((providerCode=String, providerName=String), n, it)
+          df = fill_table((providerCode=String, providerName=String), n, it)
 
           w.newsProviders(df)
         end,
 
   # HISTORICAL_NEWS
-  86 => (it, w, ver) -> w.historicalNews(slurp((Int,String,String,String,String), it)...),
+  86 => (it, w, ver, Tab=Dict) -> w.historicalNews(slurp((Int,String,String,String,String), it)...),
 
   # HISTORICAL_NEWS_END
-  87 => (it, w, ver) -> w.historicalNewsEnd(slurp((Int,Bool), it)...),
+  87 => (it, w, ver, Tab=Dict) -> w.historicalNewsEnd(slurp((Int,Bool), it)...),
 
   # HEAD_TIMESTAMP
-  88 => (it, w, ver) -> w.headTimestamp(slurp((Int,String), it)...),
+  88 => (it, w, ver, Tab=Dict) -> w.headTimestamp(slurp((Int,String), it)...),
 
   # HISTOGRAM_DATA
-  89 => function(it, w, ver)
+  89 => function(it, w, ver, Tab=Dict)
 
           reqId::Int,
           n::Int = it
 
-          df = fill_df((price=Float64, size=Float64), n, it)
+          df = fill_table((price=Float64, size=Float64), n, it)
 
           w.histogramData(reqId, df)
         end,
 
   # HISTORICAL_DATA_UPDATE
-  90 => function(it, w, ver)
+  90 => function(it, w, ver, Tab=Dict)
 
           reqId::Int = pop(it)
 
@@ -766,24 +766,24 @@ const process = Dict(
         end,
 
   # REROUTE_MKT_DATA_REQ
-  91 => (it, w, ver) -> w.rerouteMktDataReq(slurp((Int,Int,String), it)...),
+  91 => (it, w, ver, Tab=Dict) -> w.rerouteMktDataReq(slurp((Int,Int,String), it)...),
 
   # REROUTE_MKT_DEPTH_REQ
-  92 => (it, w, ver) -> w.rerouteMktDepthReq(slurp((Int,Int,String), it)...),
+  92 => (it, w, ver, Tab=Dict) -> w.rerouteMktDepthReq(slurp((Int,Int,String), it)...),
 
   # MARKET_RULE
-  93 => function(it, w, ver)
+  93 => function(it, w, ver, Tab=Dict)
 
           marketRuleId::Int,
           n::Int = it
 
-          df = fill_df((lowEdge=Float64, increment=Float64), n, it)
+          df = fill_table((lowEdge=Float64, increment=Float64), n, it)
 
           w.marketRule(marketRuleId, df)
         end,
 
   # PNL
-  94 => function(it, w, ver)
+  94 => function(it, w, ver, Tab=Dict)
 
           reqId::Int,
           dailyPnL::Float64,
@@ -794,7 +794,7 @@ const process = Dict(
         end,
 
   # PNL_SINGLE
-  95 => function(it, w, ver)
+  95 => function(it, w, ver, Tab=Dict)
 
           reqId::Int,
           pos::Int,
@@ -808,12 +808,12 @@ const process = Dict(
         end,
 
   # HISTORICAL_TICKS
-  96 => function(it, w, ver)
+  96 => function(it, w, ver, Tab=Dict)
 
           reqId::Int,
           n::Int = it
 
-          df = fill_df((time=Int, ignore=Int, price=Float64, size=Float64), n, it)
+          df = fill_table((time=Int, ignore=Int, price=Float64, size=Float64), n, it)
 
           select!(df, Not(:ignore))
 
@@ -823,12 +823,12 @@ const process = Dict(
         end,
 
   # HISTORICAL_TICKS_BID_ASK
-  97 => function(it, w, ver)
+  97 => function(it, w, ver, Tab=Dict)
 
           reqId::Int,
           n::Int = it
 
-          df = fill_df((time=Int, mask=Int, priceBid=Float64, priceAsk=Float64,
+          df = fill_table((time=Int, mask=Int, priceBid=Float64, priceAsk=Float64,
                         sizeBid=Float64, sizeAsk=Float64),
                        n, it)
 
@@ -840,12 +840,12 @@ const process = Dict(
         end,
 
   # HISTORICAL_TICKS_LAST
-  98 => function(it, w, ver)
+  98 => function(it, w, ver, Tab=Dict)
 
           reqId::Int,
           n::Int = it
 
-          df = fill_df((time=Int, mask=Int, price=Float64, size=Float64,
+          df = fill_table((time=Int, mask=Int, price=Float64, size=Float64,
                         exchange=String, specialConditions=String),
                        n, it)
 
@@ -857,7 +857,7 @@ const process = Dict(
         end,
 
   # TICK_BY_TICK
-  99 => function(it, w, ver)
+  99 => function(it, w, ver, Tab=Dict)
 
           reqId::Int,
           ticktype::Int,
@@ -895,10 +895,10 @@ const process = Dict(
         end,
 
   # ORDER_BOUND
- 100 => (it, w, ver) -> w.orderBound(collect(Int, take(it, 3))...),
+ 100 => (it, w, ver, Tab=Dict) -> w.orderBound(collect(Int, take(it, 3))...),
 
   # COMPLETED_ORDER
- 101 => function(it, w, ver)
+ 101 => function(it, w, ver, Tab=Dict)
 
           o = Order()
           c = Contract()
@@ -1036,19 +1036,19 @@ const process = Dict(
          end,
 
   # COMPLETED_ORDERS_END
- 102 => (it, w, ver) -> w.completedOrdersEnd(),
+ 102 => (it, w, ver, Tab=Dict) -> w.completedOrdersEnd(),
 
   # REPLACE_FA_END
- 103 => (it, w, ver) -> w.replaceFAEnd(slurp((Int,String), it)...),
+ 103 => (it, w, ver, Tab=Dict) -> w.replaceFAEnd(slurp((Int,String), it)...),
 
  # WSH_META_DATA
- 104 => (it, w, ver) -> w.wshMetaData(slurp((Int,String), it)...),
+ 104 => (it, w, ver, Tab=Dict) -> w.wshMetaData(slurp((Int,String), it)...),
 
  # WSH_EVENT_DATA
- 105 => (it, w, ver) -> w.wshEventData(slurp((Int,String), it)...),
+ 105 => (it, w, ver, Tab=Dict) -> w.wshEventData(slurp((Int,String), it)...),
 
  # HISTORICAL_SCHEDULE
- 106 => function(it, w, ver)
+ 106 => function(it, w, ver, Tab=Dict)
 
           reqId::Int,
           startDateTime::String,
@@ -1056,11 +1056,11 @@ const process = Dict(
           timeZone::String,
           n::Int = it
 
-          df = fill_df((startDateTime=String, endDateTime=String, refDate=String), n, it)
+          df = fill_table((startDateTime=String, endDateTime=String, refDate=String), n, it)
 
           w.historicalSchedule(reqId, startDateTime, endDateTime, timeZone, df)
         end,
 
   # USER_INFO
-  107 => (it, w, ver) -> w.userInfo(slurp((Int,String), it)...)
+  107 => (it, w, ver, Tab=Dict) -> w.userInfo(slurp((Int,String), it)...)
 )

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -19,11 +19,11 @@ end
 
 Process one message and dispatch the appropriate callback. **Blocking**.
 """
-function check_msg(ib, w)
+function check_msg(ib, w, Tab=Dict)
 
   it = read_msg(ib.socket)
 
-  decode(it, w, ib.version)
+  decode(it, w, ib.version, Tab)
 end
 
 
@@ -35,14 +35,14 @@ If `flush=true`, messages are read but callbacks are not dispatched.
 
 Return number of messages processed.
 """
-function check_all(ib, w, flush=false)
+function check_all(ib, w, flush=false, Tab=Dict)
 
   count = 0
   while bytesavailable(ib.socket) > 0 || ib.socket.status == Base.StatusOpen # =3
 
     it = read_msg(ib.socket)
 
-    flush || decode(it, w, ib.version)
+    flush || decode(it, w, ib.version, Tab)
 
     count += 1
   end
@@ -56,12 +56,12 @@ end
 
 Start a new [`Task`](@ref) to process messages asynchronously.
 """
-function start_reader(ib, w)
+function start_reader(ib, w, Tab=Dict)
 
   @async  begin
             try
               while true
-                check_msg(ib, w)
+                check_msg(ib, w, Tab)
               end
 
             catch e

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -230,7 +230,7 @@ function simple_wrap()
                  println("receiveFA: $faDataType")
                end,
 
-    historicalData= function(reqId::Int, bar::DataFrame)
+    historicalData= function(reqId::Int, bar)
                       d[:history] = bar
                       println("historicalData: $reqId $(size(bar))")
                     end,
@@ -314,7 +314,7 @@ function simple_wrap()
                      println("symbolSamples: $reqId")
                    end,
 
-    mktDepthExchanges= function(depthMktDataDescriptions::DataFrame)
+    mktDepthExchanges= function(depthMktDataDescriptions::Dict)
                         d[:mktdepthexchanges] = depthMktDataDescriptions
                         println("mktDepthExchanges")
                       end,
@@ -322,7 +322,7 @@ function simple_wrap()
     tickNews= (tickerId::Int, timeStamp::Int, providerCode::String, articleId::String, headline::String, extraData::String) ->
                 println("tickNews: $tickerId $timeStamp $providerCode $articleId $headline $extraData"),
 
-    smartComponents= function(reqId::Int, theMap::DataFrame)
+    smartComponents= function(reqId::Int, theMap::Dict)
                        d[:smartcomponents] = theMap
                        println("smartComponents: $reqId $(size(theMap))")
                      end,
@@ -332,7 +332,7 @@ function simple_wrap()
                              something(minTick, "NA"),
                              " $bboExchange $snapshotPermissions"),
 
-    newsProviders= function(newsProviders::DataFrame)
+    newsProviders= function(newsProviders::Dict)
                      d[:newsproviders] = newsProviders
                      println("newsProviders")
                    end,
@@ -350,7 +350,7 @@ function simple_wrap()
 
     headTimestamp= (reqId::Int, headTimestamp::String) -> println("headTimestamp: $reqId $headTimestamp"),
 
-    histogramData= function(reqId::Int, data::DataFrame)
+    histogramData= function(reqId::Int, data::Dict)
                     d[:histogram] = data
                     println("histogramData: $reqId")
                   end,
@@ -364,7 +364,7 @@ function simple_wrap()
     rerouteMktDepthReq= (reqId::Int, conid::Int, exchange::String) ->
                           println("rerouteMktDepthReq: $reqId $conid $exchange"),
 
-    marketRule= function(marketRuleId::Int, priceIncrements::DataFrame)
+    marketRule= function(marketRuleId::Int, priceIncrements::Dict)
                   d[:marketrule] = priceIncrements
                   println("marketRule: $marketRuleId")
                 end,
@@ -378,17 +378,17 @@ function simple_wrap()
                          something(realizedPnL, "NA"),   " ",
                          value),
 
-    historicalTicks= function(reqId::Int, ticks::DataFrame, done::Bool)
+    historicalTicks= function(reqId::Int, ticks::Dict, done::Bool)
                        d[:historyticks] = ticks
                        println("historicalTicks: $reqId $done")
                      end,
 
-    historicalTicksBidAsk= function(reqId::Int, ticks::DataFrame, done::Bool)
+    historicalTicksBidAsk= function(reqId::Int, ticks::Dict, done::Bool)
                              d[:historyticksbidask] = ticks
                              println("historicalTicksBidAsk: $reqId $done")
                            end,
 
-    historicalTicksLast= function(reqId::Int, ticks::DataFrame, done::Bool)
+    historicalTicksLast= function(reqId::Int, ticks::Dict, done::Bool)
                            d[:historytickslast] = ticks
                            println("historicalTicksLast: $reqId $done")
                          end,
@@ -420,7 +420,7 @@ function simple_wrap()
 
     wshEventData= (reqId::Int, dataJson::String) -> println("wshEventData: $reqId $dataJson"),
 
-    historicalSchedule= function(reqId::Int, startDateTime::String, endDateTime::String, timeZone::String, sessions::DataFrame)
+    historicalSchedule= function(reqId::Int, startDateTime::String, endDateTime::String, timeZone::String, sessions::Dict)
                           d[:schedule] = sessions
                           println("historicalSchedule: $reqId $startDateTime $endDateTime $timeZone")
                         end,

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,0 @@
-[deps]
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/decode.jl
+++ b/test/decode.jl
@@ -46,7 +46,7 @@
 
   # slurp
   reset!(it)
-  @test Jib.Reader.slurp((Int, Float64, String), it) === (1, 0., "action")
+  @test Jib.Reader.slurp((Int, Float64, String), it) === (1, 0.0, "action")
 
   reset!(it)
   @test Jib.Reader.slurp(Jib.ComboLeg, it) == Jib.ComboLeg(conId=1, action="action")
@@ -69,13 +69,22 @@
   @test_logs (:error, "unmask(): wrong attribs") Jib.Reader.unmask(NamedTuple{(:a, :b),NTuple{2,Bool}}, 4)
 
   # tagvalue2nt()
-  v =  ["a", "1", "b", "2"]
+  v = ["a", "1", "b", "2"]
   it = makeit(v)
   @test Jib.Reader.tagvalue2nt(2, it) == (a="1", b="2")
 
-  # fill_df
+  # fill_table
   reset!(it)
-  @test Jib.Reader.fill_df((a=String, b=Int), 2, it) == DataFrame(:a => ["a", "b"], :b => [1, 2])
+  # Test default implementation
+  dict = Dict{Symbol,Vector}()
+  dict[:a] = ["a", "b"]
+  dict[:b] = [1, 2]
+  @test Jib.Reader.fill_table((a=String, b=Int), 2, it) == dict
+
+  # Test for DataFrames
+  reset!(it)
+  @test Jib.Reader.fill_table((a=String, b=Int), 2, it, DataFrame) == DataFrame(:a => ["a", "b"], :b => [1, 2])
+
 
   # process
   @test typeof(Jib.Reader.process) == Dict{Int,Function}


### PR DESCRIPTION
Hello @lbilli,

I want to merge 4 commits:
- added a .gitignore at the root to avoid pushing the Manifest.
- removed the test/Project.toml as julia offers a standard way to do this (implemented in this PR.)
- made DataFrame an optional format to get data (where applicable). The default format is now a `Dict{Symbol, Vector}`
DataFrame is still natively handled through extensions, no regression on this. README updated accordingly.
- Added the necessary entry to the Project.toml for julia < 1.9 to handle the extension.

I hope you'll merge this PR. As the author of https://github.com/oliviermilla/Lucky.jl , I would very much love to connect to IB through Jib.jl. This is preliminary work to avoid automatically load the DataFrames package. 

Next step would be to release this as an official package in the general repository. The reason is that integration of Lucky and Jib needs to be done through extensions and for some reason, julia (1.10.1) still does not allow this easily when pulling the package from Github. If you're ok with this, I'd be happy to help you do that if needed.

Best!! 🚀 

Olivier